### PR TITLE
Remove invalid input from the entry box

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Binary is officially available as a flatpak on Flathub.
 ## Translations
 Binary uses [Weblate](https://hosted.weblate.org/projects/binary/binary-app/) for translations. Note that we're currently still in the trial period for Weblate, and this is subject to change.
 
-For automatically creating a .pot file everytime a new string is added, use update_translations.sh. This script was adapted from from [Letterpress](https://gitlab.gnome.org/World/Letterpress/-/tree/main) by Gregor Niehl, who in term adapted it from TheEvilSkeleton.
+For automatically creating a .pot file everytime a new string is added, use update_translations.sh. This script was adapted from [Letterpress](https://gitlab.gnome.org/World/Letterpress/-/tree/main) by Gregor Niehl, who in term adapted it from TheEvilSkeleton.
   
 ## Testing/building
 GNOME Builder is the recommended way to build and test this app.

--- a/src/window.py
+++ b/src/window.py
@@ -102,6 +102,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = dec2bin(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.decCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     bits = bitCount(ans)
@@ -116,6 +117,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = dec2hex(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.decCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     self.bitLbl.set_visible(False)
@@ -129,6 +131,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = hex2dec(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.hexCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     self.bitLbl.set_visible(False)
@@ -142,6 +145,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = hex2bin(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.hexCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     bits = bitCount(ans)
@@ -156,6 +160,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = bin2hex(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.binCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     bits = bitCount(inStr)

--- a/src/window.py
+++ b/src/window.py
@@ -184,3 +184,4 @@ class BinaryWindow(Adw.ApplicationWindow):
         inStr = self.entry.get_text()
         inStr = inStr[:-1]
         self.entry.set_text(inStr)
+        self.entry.set_position(len(inStr))

--- a/src/window.py
+++ b/src/window.py
@@ -58,6 +58,11 @@ class BinaryWindow(Adw.ApplicationWindow):
         title="Hexadecimal only accepts the digits 0-9 and A-F",
         timeout=toastTimeout,
     )
+    # Toast to tell the user input and output bases are the same
+    sameToast = Adw.Toast(
+        title="Input and output bases are the same",
+        timeout=1.5,
+    )
 
     @Gtk.Template.Callback()
     def swap(self, *kwargs):
@@ -160,11 +165,8 @@ class BinaryWindow(Adw.ApplicationWindow):
         # Same number bases
         elif self.inDropdown.get_selected() == self.outDropdown.get_selected():
             # Toast to tell the user they are converting between the same number format
-            sameToast = Adw.Toast(
-                title="Input and output bases are the same",
-                timeout=1.5,
-            )
-            self.overlay.add_toast(sameToast)
+            self.overlay.add_toast(self.sameToast)
+            return
 
     def blank(self, *kwargs):
         # Return the label to it's original content. Using a function for this ensures it's always the same value, and makes it more consistent.

--- a/src/window.py
+++ b/src/window.py
@@ -172,6 +172,8 @@ class BinaryWindow(Adw.ApplicationWindow):
         elif self.inDropdown.get_selected() == self.outDropdown.get_selected():
             # Toast to tell the user they are converting between the same number format
             self.overlay.add_toast(self.sameToast)
+            self.cleanEntry()
+            self.blank()
             return
 
     def blank(self, *kwargs):

--- a/src/window.py
+++ b/src/window.py
@@ -185,5 +185,5 @@ class BinaryWindow(Adw.ApplicationWindow):
     def cleanEntry(self, *kwargs):
         inStr = self.entry.get_text()
         inStr = inStr[:-1]
-        self.entry.set_text(inStr)
+        self.entry.get_buffer().set_text(inStr, len(inStr))
         self.entry.set_position(len(inStr))

--- a/src/window.py
+++ b/src/window.py
@@ -184,6 +184,4 @@ class BinaryWindow(Adw.ApplicationWindow):
 
     def cleanEntry(self, *kwargs):
         inStr = self.entry.get_text()
-        inStr = inStr[:-1]
-        self.entry.get_buffer().set_text(inStr, len(inStr))
-        self.entry.set_position(len(inStr))
+        self.entry.get_buffer().delete_text((len(inStr) - 1), -1)

--- a/src/window.py
+++ b/src/window.py
@@ -81,6 +81,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = bin2dec(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.binCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     # Set the output label and bit counter label
@@ -171,3 +172,8 @@ class BinaryWindow(Adw.ApplicationWindow):
         self.bitLbl.set_visible(True)
         self.outLbl.set_text("0")
         self.bitLbl.set_text("Bits: none")
+
+    def cleanEntry(self, *kwargs):
+        inStr = self.entry.get_text()
+        inStr = inStr[:-1]
+        self.entry.set_text(inStr)

--- a/src/window.py
+++ b/src/window.py
@@ -97,6 +97,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = dec2bin(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.decCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     bits = bitCount(ans)
@@ -111,6 +112,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = dec2hex(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.decCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     self.bitLbl.set_visible(False)
@@ -124,6 +126,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = hex2dec(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.hexCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     self.bitLbl.set_visible(False)
@@ -137,6 +140,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = hex2bin(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.hexCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     bits = bitCount(ans)
@@ -151,6 +155,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = bin2hex(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.binCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     bits = bitCount(inStr)

--- a/src/window.py
+++ b/src/window.py
@@ -172,7 +172,7 @@ class BinaryWindow(Adw.ApplicationWindow):
         elif self.inDropdown.get_selected() == self.outDropdown.get_selected():
             # Toast to tell the user they are converting between the same number format
             self.overlay.add_toast(self.sameToast)
-            self.cleanEntry()
+            self.entry.get_buffer().set_text("", -1)
             self.blank()
             return
 

--- a/src/window.py
+++ b/src/window.py
@@ -86,6 +86,7 @@ class BinaryWindow(Adw.ApplicationWindow):
                 ans = bin2dec(inStr)
                 if ans == "char":
                     self.overlay.add_toast(self.binCharToast)
+                    self.cleanEntry()
                     return
                 else:
                     # Set the output label and bit counter label
@@ -173,3 +174,8 @@ class BinaryWindow(Adw.ApplicationWindow):
         self.bitLbl.set_visible(True)
         self.outLbl.set_text("0")
         self.bitLbl.set_text("Bits: none")
+
+    def cleanEntry(self, *kwargs):
+        inStr = self.entry.get_text()
+        inStr = inStr[:-1]
+        self.entry.set_text(inStr)

--- a/src/window.py
+++ b/src/window.py
@@ -41,20 +41,22 @@ class BinaryWindow(Adw.ApplicationWindow):
         super().__init__(**kwargs)
         self.outDropdown.set_selected(1) # Set the output to decimal by default
 
+    toastTimeout = 1
+
     # Toast to tell the user decimal only numeric values
     decCharToast = Adw.Toast(
         title="Decimal only accepts the digits 0-9",
-        timeout=1.5,
+        timeout=toastTimeout,
     )
     # Toast to tell the user binary only accepts 0 or 1 digits
     binCharToast = Adw.Toast(
         title="Binary only accepts the digits 0 and 1",
-        timeout=1.5,
+        timeout=toastTimeout,
     )
     # Toast to tell the user binary only accepts 0 or 1 digits
     hexCharToast = Adw.Toast(
         title="Hexadecimal only accepts the digits 0-9 and A-F",
-        timeout=1.5,
+        timeout=toastTimeout,
     )
 
     @Gtk.Template.Callback()

--- a/src/window.py
+++ b/src/window.py
@@ -182,3 +182,4 @@ class BinaryWindow(Adw.ApplicationWindow):
         inStr = self.entry.get_text()
         inStr = inStr[:-1]
         self.entry.set_text(inStr)
+        self.entry.set_position(len(inStr))

--- a/src/window.ui
+++ b/src/window.ui
@@ -90,6 +90,7 @@
                                     <style>
                                       <class name="bin"/>
                                     </style>
+                                    <property name="enable-undo">false</property>
                                     <property name="placeholder-text" translatable="yes">Input</property>
                                     <property name="margin-end">10</property>
                                     <signal name="changed" handler="inputHandler" swapped="no" />


### PR DESCRIPTION
Closes issue #3 

This pull request should remove invalid input from the entry box, such that it only contains valid letters. Opening a PR instead of commit directly so that I can hopefully get feedback on this.

However, this has current UX and technical issues that need to be addressed before I'm confident merging this back into the main codebase:

- [x] The cursor position of the entry moves to the start of the box, when it should stay in the place it is now. I need to find a way to either not change it at all, or at least make it look like it isn't moving. 
- [x] This causes a GTK warning of "Cannot [begin/end] irreversible action while in user action":
![Screenshot from 2024-01-18 17-08-02](https://github.com/fizzyizzy05/binary/assets/85719751/7a12ad02-44b4-47f2-a999-3b4ced2623ee)
- [x] This functionality means that undo doesn't go back to the next valid input directly. Instead it goes to the invalid input, which causes it to be cleaned, and then the user has to undo again. Not a critical issue, but something that needs to be resolved before merging.