### PR TITLE
Use `ExternalProgram.full_path`

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,7 @@ gnome.compile_resources('binary',
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('PYTHON', python.find_installation('python3').full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', get_option('prefix') / get_option('localedir'))
 conf.set('pkgdatadir', pkgdatadir)


### PR DESCRIPTION
This addresses the following warning during build time:

```
WARNING: Deprecated features used:
 * 0.55.0: {'ExternalProgram.path'}
```