### PR TITLE
Add `.flatpak-builder/` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder/


### PR DESCRIPTION
This is useful for GNOME Builder users, where building the app would pollute the git status when adding or removing files.