### PR TITLE
window: make arrows visibly inactive

### DIFF
--- a/src/binary.gresource.xml
+++ b/src/binary.gresource.xml
@@ -4,6 +4,7 @@
     <file preprocess="xml-stripblanks">window.ui</file>
     <file preprocess="xml-stripblanks">preferences.ui</file>
     <file>style.css</file>
+    <file>style-hc.css</file>
     <file>style-dark.css</file>
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/vertical-arrows-symbolic.svg</file>

--- a/src/style-hc.css
+++ b/src/style-hc.css
@@ -1,3 +1,3 @@
 .typing-label {
-  opacity: 0.85;
+  opacity: 0.75;
 }

--- a/src/style-hc.css
+++ b/src/style-hc.css
@@ -1,0 +1,3 @@
+.typing-label {
+  opacity: 0.85;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -17,4 +17,5 @@
 .typing-label {
   font-size: 0.9em;
   opacity: 0.5;
+  font-weight: 700;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -13,3 +13,8 @@
   background: transparent;
   box-shadow: none;
 }
+
+.typing-label {
+  font-size: 0.9em;
+  opacity: 0.5;
+}

--- a/src/window.blp
+++ b/src/window.blp
@@ -94,10 +94,6 @@ template $BinaryWindow: Adw.ApplicationWindow {
               icon-name: "vertical-arrows-symbolic";
             }
 
-            Label {
-              label: _("Just start typing");
-            }
-
             styles [
               "typing-label"
             ]

--- a/src/window.blp
+++ b/src/window.blp
@@ -81,11 +81,26 @@ template $BinaryWindow: Adw.ApplicationWindow {
             }
           }
 
-          Image {
-            icon-size: normal;
-            icon-name: "vertical-arrows-symbolic";
+          Box {
             margin-top: 18;
             margin-bottom: 12;
+            valign: center;
+            halign: center;
+            hexpand: true;
+            spacing: 9;
+
+            Image {
+              icon-size: normal;
+              icon-name: "vertical-arrows-symbolic";
+            }
+
+            Label {
+              label: _("Just start typing");
+            }
+
+            styles [
+              "typing-label"
+            ]
           }
 
           CenterBox {


### PR DESCRIPTION
the arrows previously looked the same as the menu button before, which caused users to believe it was clickable when it wasn't. in lieu of bringing back the swap button, this should make this decorative element more clearly decorative and inactive.

Before: 
![image](https://github.com/user-attachments/assets/61eca4f4-1a2b-4967-b95d-c81c176c95fe)
After:
![image](https://github.com/user-attachments/assets/6ed4977c-ead0-4e89-8743-fde2275a07a2)


closes #21