### PR TITLE
Get ready for GNOME 47

### DIFF
--- a/io.github.fizzyizzy05.binary.json
+++ b/io.github.fizzyizzy05.binary.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.fizzyizzy05.binary",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "master",
     "sdk" : "org.gnome.Sdk",
     "command" : "binary",
     "finish-args" : [

--- a/src/binary.gresource.xml
+++ b/src/binary.gresource.xml
@@ -4,7 +4,6 @@
     <file preprocess="xml-stripblanks">window.ui</file>
     <file preprocess="xml-stripblanks">preferences.ui</file>
     <file>style.css</file>
-    <file>style-dark.css</file>
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/vertical-arrows-symbolic.svg</file>
     <file alias="metainfo.xml" preprocess="xml-stripblanks">../data/io.github.fizzyizzy05.binary.metainfo.xml</file>

--- a/src/style-dark.css
+++ b/src/style-dark.css
@@ -1,2 +1,0 @@
-@define-color accent_color @green_1;
-@define-color accent_bg_color @green_4;

--- a/src/style.css
+++ b/src/style.css
@@ -1,6 +1,3 @@
-@define-color accent_color @green_5;
-@define-color accent_bg_color @green_3;
-
 .mono {
   font-family: monospace;
 }
@@ -12,4 +9,10 @@
 .flat-dropdown button:not(:checked):not(:hover) {
   background: transparent;
   box-shadow: none;
+}
+
+.typing-label {
+  font-size: 0.9em;
+  opacity: 0.5;
+  font-weight: 700;
 }


### PR DESCRIPTION
This PR bumps the platform up to master and provides space for working on changes that are part of GNOME 47. Notably, we no longer set the accent colour to green in CSS and instead use the system accent colours. Once released, I'll change this up to 47 and merge it.

Closes #23