### PR TITLE
build: Don't override install mode for the binary

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -35,7 +35,6 @@ configure_file(
   configuration: conf,
   install: true,
   install_dir: get_option('bindir'),
-  install_mode: 'r-xr--r--'
 )
 
 binary_sources = [


### PR DESCRIPTION
Files in bindir need the marked as executable, otherwise they cannot be executed.