### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/io.github.fizzyizzy05.binary.desktop.in
+++ b/data/io.github.fizzyizzy05.binary.desktop.in
@@ -8,4 +8,5 @@ Type=Application
 Categories=GTK;Utility;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=binary;decimal;hexadecimal;base;convert;
+DBusActivatable=true
 StartupNotify=true

--- a/data/io.github.fizzyizzy05.binary.service.in
+++ b/data/io.github.fizzyizzy05.binary.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=io.github.fizzyizzy05.binary
+Exec=@bindir@/binary --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -33,4 +33,14 @@ test('Validate schema file',
      compile_schemas,
      args: ['--strict', '--dry-run', meson.current_source_dir()])
 
+service_conf = configuration_data()
+service_conf.set('bindir', get_option('prefix') / get_option('bindir'))
+configure_file(
+          input: 'io.github.fizzyizzy05.binary.service.in',
+         output: 'io.github.fizzyizzy05.binary.service',
+  configuration: service_conf,
+        install: true,
+    install_dir: get_option('datadir') / 'dbus-1' / 'services'
+)
+
 subdir('icons')


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html