### PR TITLE
appstream: Fix app id

### DIFF
--- a/data/io.github.fizzyizzy05.binary.metainfo.xml.in
+++ b/data/io.github.fizzyizzy05.binary.metainfo.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-	<id>io.github.fizzyizzy05.binary.desktop</id>
+	<id>io.github.fizzyizzy05.binary</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
   <name>Binary</name>


### PR DESCRIPTION
The .desktop extension is not valid for app ids and [causing issues](https://github.com/flathub/flathub/issues/4222#issuecomment-2018677522).